### PR TITLE
Adds >= to engines, supporting newer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "url" : "https://github.com/ticup/emotional.git"
   },
   "engines": {
-    "node": "0.10.x",
-    "npm": "1.2.x"
+    "node": ">=0.10.x",
+    "npm": ">=1.2.x"
   },
   "dependencies": {
     "xml2js": "*",


### PR DESCRIPTION
Works on newer versions of node & npm, just updating to allow it without warning